### PR TITLE
Fix logic in cnView_qual

### DIFF
--- a/R/cnView_qual.R
+++ b/R/cnView_qual.R
@@ -41,9 +41,7 @@ cnView_qual <- function(x, y, z, genome, CNscale)
                            " column but CNscale is set to \"absolute\"!")
             warning(memo)
         }
-    } else if(CNscale == "relative") {
-        next
-    } else {
+    } else if(CNscale != "relative") {
         memo <- paste0("Did not recognize input to parameter CNscale",
                        " please specify one of \"relative\" or \"absolute\"!")
         stop(memo)


### PR DESCRIPTION
`next` is not meant to be used outside loops. Thus, the logic is adjusted
to have the function fail in case CNscale is not "relative" (and we have
already evaluated the "absolute" condition).

With this I can plot log2ratios from CGH and sequencing data, hereby
fixing issue #305.