### PR TITLE
Remove unused (and to be deprecated) import

### DIFF
--- a/R/compIdent_buildMain.R
+++ b/R/compIdent_buildMain.R
@@ -9,7 +9,6 @@
 #' @return ggplot2 grob object
 #' @import ggplot2
 #' @importFrom grid unit.pmax
-#' @importFrom gridExtra rbind.gtable
 #' @importFrom gridExtra arrangeGrob
 #' @importFrom gtable gtable_add_rows
 #' @importFrom gtable gtable_add_grob


### PR DESCRIPTION
I'm removing rbind.gtable from gridExtra (renamed gtable_rbind). It looks like it wasn't used here.