### PR TITLE
Consolidation of chr prefix naming

### DIFF
--- a/R/compIdent_bamRcnt.R
+++ b/R/compIdent_bamRcnt.R
@@ -37,11 +37,11 @@ compIdent_bamRcnt <- function(bamfile, genome, target=NULL, debug=FALSE)
     # Target locations must conform to the bam files being read in, create
     # two versions one with "chr1" and the other with "1" and use whichever is
     # appropriate
+    target.chr <- target
     if(any(grepl("chr", target$chr)))
     {
         target$chr <- gsub("chr", "", target$chr)
     } else {
-        target.chr <- target
         target.chr$chr <- paste0("chr", target$chr)
     }
     


### PR DESCRIPTION
Using target parameter with 'chr' column values prepended with 'chr' (as opposed to just a number) results in target.chr not being initialized. This results in further errors downstream.